### PR TITLE
Update to flush metadata field references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+## [v0.10.0]
+
+### Changed
+
+- The way metadata field references are treated. When a processor is re-registers, and the windows also get registered, the old metadata field references get flushed.
 
 ## [v0.9.0]
 

--- a/core/internal/datalayers/postgresql/funcs.go
+++ b/core/internal/datalayers/postgresql/funcs.go
@@ -138,6 +138,20 @@ func (d *Datalayer) createMetadataFieldBridge(
 	return nil
 }
 
+func (d *Datalayer) flushMetadataFields(
+	ctx context.Context,
+	tx types.Tx,
+	windowTypeId int64,
+) error {
+	pgTx := tx.(*PgTx)
+	qtx := d.queries.WithTx(pgTx.tx)
+	err := qtx.FlushMetadataFieldBridgeForWindowType(ctx, windowTypeId)
+	if err != nil {
+		return fmt.Errorf("could not flush metadata fields for window type id: %v - %v", windowTypeId, err)
+	}
+	return nil
+}
+
 func (d *Datalayer) addAlgorithm(
 	ctx context.Context,
 	tx types.Tx,

--- a/core/internal/datalayers/postgresql/main.go
+++ b/core/internal/datalayers/postgresql/main.go
@@ -21,7 +21,7 @@ func (d *Datalayer) RegisterProcessor(
 	ctx context.Context,
 	proc *pb.ProcessorRegistration,
 ) error {
-	slog.Debug("creating processor", "protobuf", proc)
+	slog.Debug("registering processor", "processor", proc)
 
 	tx, err := d.WithTx(ctx)
 
@@ -65,6 +65,12 @@ func (d *Datalayer) RegisterProcessor(
 		windowTypeId, err := d.createWindowType(ctx, tx, windowType)
 		if err != nil {
 			slog.Error("could not create window type", "error", err)
+			return err
+		}
+
+		// remove any existing metadata field references for this window
+		err = d.flushMetadataFields(ctx, tx, windowTypeId)
+		if err != nil {
 			return err
 		}
 

--- a/core/internal/datalayers/postgresql/query.sql
+++ b/core/internal/datalayers/postgresql/query.sql
@@ -56,6 +56,10 @@ SET
   window_type_id = EXCLUDED.window_type_id,
   metadata_fields_id = EXCLUDED.metadata_fields_id;
 
+-- name: FlushMetadataFieldBridgeForWindowType :exec
+DELETE FROM metadata_fields_references
+WHERE window_type_id = sqlc.arg('window_type_id');
+
 -- name: CreateAlgorithm :exec
 WITH processor_id AS (
   SELECT id FROM processor p

--- a/core/internal/datalayers/postgresql/query.sql.go
+++ b/core/internal/datalayers/postgresql/query.sql.go
@@ -299,6 +299,16 @@ func (q *Queries) CreateWindowTypeMetadataFieldBridge(ctx context.Context, arg C
 	return err
 }
 
+const flushMetadataFieldBridgeForWindowType = `-- name: FlushMetadataFieldBridgeForWindowType :exec
+DELETE FROM metadata_fields_references
+WHERE window_type_id = $1
+`
+
+func (q *Queries) FlushMetadataFieldBridgeForWindowType(ctx context.Context, windowTypeID int64) error {
+	_, err := q.db.Exec(ctx, flushMetadataFieldBridgeForWindowType, windowTypeID)
+	return err
+}
+
 const linkAnnotationToAlgorithm = `-- name: LinkAnnotationToAlgorithm :exec
 WITH algorithm_id AS (
   SELECT


### PR DESCRIPTION
This change flushes the metadata field references when a new version of a window type is added.